### PR TITLE
add dependency to toc

### DIFF
--- a/BetterBags_DragonflightReputationInsignia.toc
+++ b/BetterBags_DragonflightReputationInsignia.toc
@@ -3,6 +3,7 @@
 ## Author: Zazou
 ## Version: 1.0.4
 ## Notes: Category for all the Dragonflight Reputation Insignia.
+## Dependencies: BetterBags
 ## X-Curse-Project-ID: 956577
 ## IconTexture: Interface\Icons\ui_majorfaction_tuskarr
 


### PR DESCRIPTION
I came across this while working on [a project of mine](https://github.com/emptyrivers/wow-bisector). Up to you if you want to merge it, but it should both prevent WoW from attempting to load this addon if BetterBags isn't installed/is disabled, and it should also prompt Curseforge & friends to install automatically BetterBags if a user tries to grab this addon first.